### PR TITLE
Added Mongo support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,61 @@ $cache = new Cache($adapter);
 
 ```
 
+### Mongo
+
+Use it to store the cache in a Mongo database. Requires the
+[(legacy) mongo extension](http://php.net/mongo) or the
+[mongodb/mongodb](https://github.com/mongodb/mongo-php-library) library.
+
+``` php
+<?php
+
+use Desarrolla2\Cache\Cache;
+use Desarrolla2\Cache\Adapter\Mongo;
+
+$client = new MongoClient($dsn);
+$database = $client->selectDatabase($dbname);
+
+$adapter = new Mongo($database);
+$adapter->setOption('ttl', 3600);
+$cache = new Cache($adapter);
+
+```
+
+By default the `items` collection is used. You specify a different collection
+as second argument of the constructor.
+
+```
+$adapter = new Mongo($database, $colname);
+$cache = new Cache($adapter);
+```
+
+Alternatively you may pass a collection object as single argument.
+
+``` php
+<?php
+
+use Desarrolla2\Cache\Cache;
+use Desarrolla2\Cache\Adapter\Mongo;
+
+$client = new MongoClient($dsn);
+$database = $client->selectDatabase($dbname);
+$collection = $database->selectCollection($colname);
+
+$adapter = new Mongo($collection);
+$adapter->setOption('ttl', 3600);
+$cache = new Cache($adapter);
+
+```
+
+_Note that expired cache items aren't automatically deleted. To keep your
+database clean, you should create a
+[ttl index](https://docs.mongodb.org/manual/core/index-ttl/)._
+
+
+```
+db.items.createIndex( { "ttl": 1 }, { expireAfterSeconds: 30 } )
+```
 
 ### Mysqli
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ Use it to store the cache in a Mongo database. Requires the
 [(legacy) mongo extension](http://php.net/mongo) or the
 [mongodb/mongodb](https://github.com/mongodb/mongo-php-library) library.
 
+You may pass either a database or collection object to the constructor. If a
+database object is passed, the `items` collection within that DB is used.
+
 ``` php
 <?php
 
@@ -167,16 +170,6 @@ $cache = new Cache($adapter);
 
 ```
 
-By default the `items` collection is used. You specify a different collection
-as second argument of the constructor.
-
-```
-$adapter = new Mongo($database, $colname);
-$cache = new Cache($adapter);
-```
-
-Alternatively you may pass a collection object as single argument.
-
 ``` php
 <?php
 
@@ -184,8 +177,8 @@ use Desarrolla2\Cache\Cache;
 use Desarrolla2\Cache\Adapter\Mongo;
 
 $client = new MongoClient($dsn);
-$database = $client->selectDatabase($dbname);
-$collection = $database->selectCollection($colname);
+$database = $client->selectDatabase($dbName);
+$collection = $database->selectCollection($collectionName);
 
 $adapter = new Mongo($collection);
 $adapter->setOption('ttl', 3600);

--- a/src/Adapter/Mongo.php
+++ b/src/Adapter/Mongo.php
@@ -21,28 +21,28 @@ use Desarrolla2\Cache\Exception\CacheException;
 class Mongo extends AbstractAdapter implements AdapterInterface
 {
     /**
-     * @var string
+     * @var MongoCollection|MongoDB\Collection
      */
     protected $collection;
 
     /**
-     * @param MongoDB|MongoDB\Database                  $database   (may be omitted)
-     * @param MongoCollection|MongoDB\Collection|string $collection
+     * @param MongoDB|MongoDB\Database|MongoCollection|MongoDB\Collection  $backend
      */
-    public function __construct($database, $collection = 'items')
+    public function __construct($backend = null)
     {
-        if ($database instanceof \MongoCollection || $database instanceof \MongoDB\Collection) {
-            $collection = $database;
-            $database = null;
+        if (!isset($backend)) {
+            $client = class_exist('MongoCollection') ? new \MongoClient() : new \MongoDB\Client();
+            $backend = $client->selectDatabase('cache');
         }
-    
-        if ($collection instanceof \MongoCollection || $collection instanceof \MongoDB\Collection) {
-            $this->collection = $collection;
-        } elseif ($database instanceof \MongoDB || $database instanceof \MongoDB\Database) {
-            $this->collection = $database->selectCollection($collection);
+            
+        if ($backend instanceof \MongoCollection || $backend instanceof \MongoDB\Collection) {
+            $this->collection = $backend;
+        } elseif ($backend instanceof \MongoDB || $backend instanceof \MongoDB\Database) {
+            $this->collection = $backend->selectCollection('items');
         } else {
             $type = (is_object($database) ? get_class($database) . ' ' : '') . gettype($database);
-            throw new CacheException("Database should be a MongoDB or MongoDB\Database, not a $type");
+            throw new CacheException("Database should be a database (MongoDB or MongoDB\Database) or " .          
+                " collection (MongoCollection or MongoDB\Collection) object, not a $type");
         }
     }
 

--- a/src/Adapter/Mongo.php
+++ b/src/Adapter/Mongo.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of the Cache package.
+ *
+ * Copyright (c) Daniel González
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Daniel González <daniel@desarrolla2.com>
+ */
+
+namespace Desarrolla2\Cache\Adapter;
+
+use Desarrolla2\Cache\Exception\CacheException;
+
+/**
+ * Mongo
+ */
+class Mongo extends AbstractAdapter implements AdapterInterface
+{
+    /**
+     * @var string
+     */
+    protected $collection;
+
+    /**
+     * @param MongoDB|MongoDB\Database                  $database   (may be omitted)
+     * @param MongoCollection|MongoDB\Collection|string $collection
+     */
+    public function __construct($database, $collection = 'items')
+    {
+        if ($database instanceof \MongoCollection || $database instanceof \MongoDB\Collection) {
+            $collection = $database;
+            $database = null;
+        }
+    
+        if ($collection instanceof \MongoCollection || $collection instanceof \MongoDB\Collection) {
+            $this->collection = $collection;
+        } elseif ($database instanceof \MongoDB || $database instanceof \MongoDB\Database) {
+            $this->collection = $database->selectCollection($collection);
+        } else {
+            $type = (is_object($database) ? get_class($database) . ' ' : '') . gettype($database);
+            throw new CacheException("Database should be a MongoDB or MongoDB\Database, not a $type");
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function del($key)
+    {
+        $tKey = $this->getKey($key);
+        $this->collection->remove(array('_id' => $tKey));
+    }
+
+    /**
+     * {@inheritdoc }
+     */
+    public function get($key)
+    {
+        $tKey = $this->getKey($key);
+        $tNow = $this->getTtl();
+        $data = $this->collection->findOne(array('_id' => $tKey, 'ttl' => array('$gte' => $tNow)));
+        if (isset($data)) {
+            return $this->unPack($data['value']);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc }
+     */
+    public function has($key)
+    {
+        $tKey = $this->getKey($key);
+        $tNow = $this->getTtl();        
+        return $this->collection->count(array('_id' => $tKey, 'ttl' => array('$gte' => $tNow))) > 0;
+    }
+
+    /**
+     * {@inheritdoc }
+     */
+    public function set($key, $value, $ttl = null)
+    {
+        $tKey = $this->getKey($key);
+        $tValue = $this->pack($value);
+        if (!$ttl) {
+            $ttl = $this->ttl;
+        }
+        $item = array(
+            '_id' => $tKey,
+            'value' => $tValue,
+            'ttl' => $this->getTtl($ttl),
+        );
+        $this->collection->update(array('_id' => $tKey), $item, array('upsert' => true));
+    }
+    
+    /**
+     * Get TTL as Date type BSON object
+     *
+     * @param  int  $ttl
+     * @return MongoDate|MongoDB\BSON\UTCDatetime
+     */
+    protected function getTtl($ttl = 0)
+    {
+        return $this->collection instanceof \MongoCollection ?
+            new \MongoDate((int) $ttl + time()) :
+            new \MongoDB\BSON\UTCDatetime(((int) $ttl + time() * 1000));
+    }
+}

--- a/tests/Adapter/MongoTest.php
+++ b/tests/Adapter/MongoTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Cache package.
+ *
+ * Copyright (c) Daniel González
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Daniel González <daniel@desarrolla2.com>
+ */
+
+namespace Desarrolla2\Test\Cache\Adapter;
+
+use Desarrolla2\Cache\Cache;
+use Desarrolla2\Cache\Adapter\Mongo;
+
+/**
+ * MongoTest
+ */
+class MongoTest extends AbstractCacheTest
+{
+    public function setUp()
+    {
+        parent::setup();
+        if (!extension_loaded('mongo')) {
+            $this->markTestSkipped(
+                'The mongo extension is not available.'
+            );
+        }
+
+        $client = new \MongoClient($this->config['mongo']['dsn']);
+        $database = $client->selectDB($this->config['mongo']['database']);
+
+        $this->cache = new Cache(
+            new Mongo($database)
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForOptions()
+    {
+        return [
+            ['ttl', 100],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForOptionsException()
+    {
+        return [
+            ['ttl', 0, '\Desarrolla2\Cache\Exception\CacheException'],
+            ['file', 100, '\Desarrolla2\Cache\Exception\CacheException'],
+        ];
+    }
+}

--- a/tests/config.json.dist
+++ b/tests/config.json.dist
@@ -7,7 +7,8 @@
     "port": "11211"
   },
   "mongo": {
-    "dns": "mongodb://localhost:27017"
+    "dsn": "mongodb://localhost:27017",
+    "database": "cache"
   },
   "mysql": {
     "user": "root",


### PR DESCRIPTION
Added Mongo support.

This was supported in 1.8, but missing in 2.0
Supports both the mongodb\mongodb library as the (legacy) mongo extension

Differenes from 1.8:
 - Constructor takes db object or collection object as argument
 - Use `_id` field rather than custom `key` field
 - Expired items are ignored rather than deleted (just like Mysqli)
 - Using upsert rather than delete + insert
 - Store TTL as date bson type to allow ttl index

Includes unit tests.
Usage guide is added to README.

Fixes desarrolla2/Cache#25