### PR TITLE
Fix pecl issue on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ before_script:
     - mysql -e 'USE `cache`; CREATE TABLE `cache` (`k` varchar(255) NOT NULL, `v` text NOT NULL, `t` int(11) NOT NULL, PRIMARY KEY (`k`)) ENGINE=InnoDB DEFAULT CHARSET=utf8;'
 
     # Install apcu
-    - sh -c "pear config-set preferred_state beta"
-    - sh -c "yes '' | pecl install apcu"
+    - "if [ $TRAVIS_PHP_VERSION == '7.0' ] || [ $TRAVIS_PHP_VERSION == 'hhvm' ]; then export APCU_VERSION=5.1.0; else export APCU_VERSION=4.0.8; fi"
+    - sh -c "yes '' | pecl install apcu-$APCU_VERSION"
     - sh -c "if [ $TRAVIS_PHP_VERSION != 'hhvm' ]; then phpenv config-add ./tests/travis/php.ini; fi"
 
     # Install dependencies


### PR DESCRIPTION
APCU 5.x requires php7, therefor it pecl won't install it for version 5.x
This causes Travis to fail without running any tests