### PR TITLE
Fix short array notation in \Desarrolla2\Cache\Adapter\File. Fix exception namespace in multiple spots.

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -66,7 +66,7 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function clearCache()
     {
-        throw new Exception('not ready yet');
+        throw new \Exception('not ready yet');
     }
 
     /**
@@ -74,7 +74,7 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function dropCache()
     {
-        throw new Exception('not ready yet');
+        throw new \Exception('not ready yet');
     }
 
     /**
@@ -91,7 +91,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Builds the key according to the prefix and other options
      *
-     * @param string key
+     * @param string $key
      * @return string
      */
     protected function buildKey($key)

--- a/src/Adapter/Apc.php
+++ b/src/Adapter/Apc.php
@@ -68,7 +68,7 @@ class Apc extends AbstractAdapter
     {
         $tKey = $this->getKey($key);
 
-        if (function_exists("\apcu_exists") || function_exists("\apc_exists")) {
+        if (function_exists('\apcu_exists') || function_exists('\apc_exists')) {
             return (boolean) ($this->apcu ? \apcu_exists($tKey) : \apc_exists($tKey));
         } else {
             $result = false;
@@ -118,6 +118,6 @@ class Apc extends AbstractAdapter
      */
     public function dropCache()
     {
-		($this->apcu ? apcu_clear_cache("user") : apc_clear_cache("user"));
+		    ($this->apcu ? apcu_clear_cache() : apc_clear_cache("user"));
     }
 }

--- a/src/Adapter/Apc.php
+++ b/src/Adapter/Apc.php
@@ -27,7 +27,7 @@ class Apc extends AbstractAdapter
     {
         $this->apcu = extension_loaded('apcu');
     }
-	
+
     /**
      * Delete a value from the cache
      *
@@ -118,6 +118,6 @@ class Apc extends AbstractAdapter
      */
     public function dropCache()
     {
-		    ($this->apcu ? apcu_clear_cache() : apc_clear_cache("user"));
+        ($this->apcu ? apcu_clear_cache() : apc_clear_cache("user"));
     }
 }

--- a/src/Adapter/File.php
+++ b/src/Adapter/File.php
@@ -97,10 +97,10 @@ class File extends AbstractAdapter
             $ttl = $this->ttl;
         }
         $item = $this->serialize(
-            [
+            array(
                 'value' => $tValue,
                 'ttl' => (int)$ttl + time(),
-            ]
+            )
         );
         if (!file_put_contents($cacheFile, $item)) {
             throw new FileCacheException('Error saving data with the key "'.$key.'" to the cache file.');
@@ -132,7 +132,7 @@ class File extends AbstractAdapter
      */
     public function clearCache()
     {
-        throw new Exception('not ready yet');
+        throw new \Exception('not ready yet');
     }
 
     /**

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -35,7 +35,7 @@ interface CacheInterface
     /**
      *
      * @return \Desarrolla2\Cache\Adapter\AdapterInterface $adapter
-     * @throws Exception
+     * @throws \Exception
      */
     public function getAdapter();
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,4 +12,4 @@
  */
 
 $loader = require_once __DIR__.'/../vendor/autoload.php';
-Ladybug\Loader::loadHelpers();
+//Ladybug\Loader::loadHelpers();


### PR DESCRIPTION
Related to:
 - https://github.com/desarrolla2/Cache/issues/20
 - https://github.com/desarrolla2/Cache/issues/33