### PR TITLE
1.8 fix phpunit tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,13 @@
     "php": ">=5.3.3"
   },
   "require-dev": {
-    "predis/predis": "*"
+    "predis/predis": "*",
+    "phpunit/phpunit": "^5.7",
+    "raulfraile/ladybug": "^1.0"
   },
   "autoload": {
     "psr-4": {
       "Desarrolla2\\Cache\\": "src/"
     }
-  },
-  "minimum-stability": "dev"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   },
   "require-dev": {
     "predis/predis": "*",
-    "phpunit/phpunit": "^5.7",
+    "phpunit/phpunit": "^4.8",
     "raulfraile/ladybug": "^1.0"
   },
   "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,7 @@
 
     <filter>
         <whitelist>
-            <directory>./Test</directory>
+            <directory>./src</directory>
         </whitelist>
         <blacklist>
             <directory>/usr/share/pear/</directory>

--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -66,7 +66,7 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function clearCache()
     {
-        throw new Exception('not ready yet');
+        throw new \Exception('not ready yet');
     }
 
     /**
@@ -74,7 +74,7 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function dropCache()
     {
-        throw new Exception('not ready yet');
+        throw new \Exception('not ready yet');
     }
 
     /**
@@ -91,7 +91,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Builds the key according to the prefix and other options
      *
-     * @param string key
+     * @param string $key
      * @return string
      */
     protected function buildKey($key)

--- a/src/Adapter/Apc.php
+++ b/src/Adapter/Apc.php
@@ -68,7 +68,7 @@ class Apc extends AbstractAdapter
     {
         $tKey = $this->getKey($key);
 
-        if (function_exists("\apcu_exists") || function_exists("\apc_exists")) {
+        if (function_exists('\apcu_exists') || function_exists('\apc_exists')) {
             return (boolean) ($this->apcu ? \apcu_exists($tKey) : \apc_exists($tKey));
         } else {
             $result = false;
@@ -118,6 +118,6 @@ class Apc extends AbstractAdapter
      */
     public function dropCache()
     {
-		($this->apcu ? apcu_clear_cache("user") : apc_clear_cache("user"));
+		    ($this->apcu ? apcu_clear_cache() : apc_clear_cache("user"));
     }
 }

--- a/src/Adapter/Apc.php
+++ b/src/Adapter/Apc.php
@@ -27,7 +27,7 @@ class Apc extends AbstractAdapter
     {
         $this->apcu = extension_loaded('apcu');
     }
-	
+
     /**
      * Delete a value from the cache
      *
@@ -118,6 +118,6 @@ class Apc extends AbstractAdapter
      */
     public function dropCache()
     {
-		    ($this->apcu ? apcu_clear_cache() : apc_clear_cache("user"));
+        ($this->apcu ? apcu_clear_cache() : apc_clear_cache("user"));
     }
 }

--- a/src/Adapter/File.php
+++ b/src/Adapter/File.php
@@ -97,10 +97,10 @@ class File extends AbstractAdapter
             $ttl = $this->ttl;
         }
         $item = $this->serialize(
-            [
+            array(
                 'value' => $tValue,
                 'ttl' => (int)$ttl + time(),
-            ]
+            )
         );
         if (!file_put_contents($cacheFile, $item)) {
             throw new FileCacheException('Error saving data with the key "'.$key.'" to the cache file.');
@@ -132,7 +132,7 @@ class File extends AbstractAdapter
      */
     public function clearCache()
     {
-        throw new Exception('not ready yet');
+        throw new \Exception('not ready yet');
     }
 
     /**

--- a/src/Adapter/Redis.php
+++ b/src/Adapter/Redis.php
@@ -70,7 +70,7 @@ class Redis extends AbstractAdapter
         $cmd = $this->client->createCommand('EXISTS');
         $cmd->setArguments(array($key));
 
-        return $this->client->executeCommand($cmd);
+        return (bool)$this->client->executeCommand($cmd);
     }
 
     /**

--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -35,7 +35,7 @@ interface CacheInterface
     /**
      *
      * @return \Desarrolla2\Cache\Adapter\AdapterInterface $adapter
-     * @throws Exception
+     * @throws \Exception
      */
     public function getAdapter();
 

--- a/tests/Desarrolla2/Cache/Adapter/Test/MySQLTest.php
+++ b/tests/Desarrolla2/Cache/Adapter/Test/MySQLTest.php
@@ -21,6 +21,11 @@ use Desarrolla2\Cache\Adapter\MySQL;
  */
 class MySQLTest extends AbstractCacheTest
 {
+    public static function setUpBeforeClass()
+    {
+        mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+    }
+
     public function setUp()
     {
         parent::setup();
@@ -29,15 +34,20 @@ class MySQLTest extends AbstractCacheTest
                 'The MySQLnd extension is not available.'
             );
         }
-        $this->cache = new Cache(
-            new MySQL(
+
+        try {
+            $adapter = new MySQL(
                 $this->config['mysql']['host'],
                 $this->config['mysql']['user'],
                 $this->config['mysql']['password'],
                 $this->config['mysql']['database'],
                 $this->config['mysql']['port']
-            )
-        );
+            );
+        } catch (\mysqli_sql_exception $e) {
+            $this->markTestSkipped($e->getMessage());
+        }
+
+        $this->cache = new Cache($adapter);
     }
 
     /**

--- a/tests/Desarrolla2/Cache/Adapter/Test/RedisTest.php
+++ b/tests/Desarrolla2/Cache/Adapter/Test/RedisTest.php
@@ -15,6 +15,7 @@ namespace Desarrolla2\Cache\Adapter\Test;
 
 use Desarrolla2\Cache\Cache;
 use Desarrolla2\Cache\Adapter\Redis;
+use Predis\Connection\ConnectionException;
 
 /**
  * RedisTest
@@ -24,6 +25,7 @@ class RedisTest extends AbstractCacheTest
     public function setUp()
     {
         parent::setup();
+
         $this->cache = new Cache(
             new Redis()
         );
@@ -49,4 +51,21 @@ class RedisTest extends AbstractCacheTest
             array('file', 100, '\Desarrolla2\Cache\Exception\CacheException'),
         );
     }
+
+    /**
+     * Run a test.
+     *
+     * @return mixed
+     *
+     * @throws Exception|PHPUnit_Framework_Exception
+     * @throws PHPUnit_Framework_Exception
+     */
+    protected function runTest()
+    {
+        try {
+            parent::runTest();
+        } catch (ConnectionException $e) {
+            $this->markTestSkipped($e->getMessage());
+        }
+   }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,3 +13,10 @@
 
 $loader = require_once __DIR__.'/../vendor/autoload.php';
 //Ladybug\Loader::loadHelpers();
+
+error_reporting(E_ALL & ~E_DEPRECATED & ~E_STRICT);
+
+if (!file_exists(__DIR__ . '/config.yml')) {
+    copy(__DIR__ . '/config.yml.dist', __DIR__ . '/config.yml');
+}
+

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,4 +12,4 @@
  */
 
 $loader = require_once __DIR__.'/../vendor/autoload.php';
-Ladybug\Loader::loadHelpers();
+//Ladybug\Loader::loadHelpers();


### PR DESCRIPTION
Run PHPUnit tests without prior setup.
Cast Adapter\Redis::has() to a boolean

Includes the PR of @echernyavskiy
Closes #36 

Closes #34 (which is superseded)
