### PR TITLE
Remove duplicate invocation of getKey() in File::getValueFromCache()

### DIFF
--- a/src/Adapter/File.php
+++ b/src/Adapter/File.php
@@ -144,7 +144,7 @@ class File extends AbstractAdapter
 
     protected function getValueFromCache($key)
     {
-        $path = $this->getFileName($this->getKey($key));
+        $path = $this->getFileName($key);
 
         if (!file_exists($path)) {
             return;


### PR DESCRIPTION
Calling `getKey()` before passing the key to `getFileName()` from `getValueFromCache()` is not only unnecessary, it actually breaks caching if the prefix is not empty.
I discovered this from a slightly different perspective: in my application I had to inherit from `Adapter/File` and override `getKey()` so that it applies `sha1()` to it as I frequently get cache keys with colons and other garbage in them. So as with a non-empty prefix, the key gets mutated in this instance, and then gets mutated yet again by the second `getKey()` call, so the lookup key is actually completely different.