### PR TITLE
Correct wrong class name in documentation

### DIFF
--- a/docs/implementations/phpfile.md
+++ b/docs/implementations/phpfile.md
@@ -17,7 +17,7 @@ performance benefit over APCu for storing strings.
 ``` php
 use Desarrolla2\Cache\PhpFile as PhpFileCache;
 
-$cache = new FileCache();
+$cache = new PhpFileCache();
 ```
 
 ### Options


### PR DESCRIPTION
The documentation specifies importing `PhpFileCache`, but then uses `FileCache`. I suspect this is probably from copypasta.