### PR TITLE
Auto-create cache dir as it is likely not to exist

### DIFF
--- a/src/AbstractFile.php
+++ b/src/AbstractFile.php
@@ -41,6 +41,9 @@ abstract class AbstractFile extends AbstractCache
     {
         if (!$cacheDir) {
             $cacheDir = realpath(sys_get_temp_dir()) . DIRECTORY_SEPARATOR . 'cache';
+            if(!is_dir($cacheDir)) {
+                mkdir($cacheDir, 0777, true);
+            }
         }
 
         $this->cacheDir = rtrim($cacheDir, '/');


### PR DESCRIPTION
For a mini site I wanted a no options cache adapter, so I went with `PhpFile` and no arguments thinking it would put the file in the `/tmp` dir, but a subdir `cache` is used inside `/tmp` that does not exist on my system.

My change auto-creates the needed dir so everything can work without additional setup.